### PR TITLE
Migrate to Compose V2

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -1,3 +1,3 @@
 # Aliases
 alias g='git'
-alias dc='docker-compose'
+alias dc='docker compose'


### PR DESCRIPTION
### The motivation for the changes

Docker compose v1 has been [deprecated](https://docs.docker.com/compose/migrate/) since July 2023.